### PR TITLE
Update contributing guidelines for Electron app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,10 @@ We follow a structured Git workflow to maintain code quality and ensure smooth c
 ## Project Structure
 
 The project is organized into the following main directories:
-- `xtraqtivApp`: SwiftUI-based macOS application (UI/UX)
-- `xtraqtivCore`: Core business logic and Evernote integration
-- `Documentation`: User guides and project documentation
-- `Scripts`: Development, build, and CI/CD scripts
+- `xtraqtivApp`: Electron desktop application (UI/UX)
+- `xtraqtivCore`: Core backend logic and Evernote integration
+- `Documentation`: User guides and diagrams
+- `tasks`: Product requirements and development tasks
 
 ## Development Setup
 


### PR DESCRIPTION
## Summary
- describe `xtraqtivApp` as an Electron desktop application
- adjust main directory list: remove outdated `Scripts` entry and add `tasks`

## Testing
- `find xtraqtivCore -name '*.py' -print -exec python -m py_compile {} \;`

------
https://chatgpt.com/codex/tasks/task_e_684102344e7c832991243355d6f6e553