### PR TITLE
Fix gitignore rule and add tests folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,8 @@ temp/
 # -----------------------------------------------------------------------------
 
 # Development scripts (temporary)
-test_*.py
+# Ignore root-level test scripts but keep tests/ directory
+/test_*.py
 run_*.sh
 debug_*.py
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,14 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from xtraqtivCore.api import app
+
+client = TestClient(app)
+
+def test_root_endpoint():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json().get("message") == "Evernote Extractor API"


### PR DESCRIPTION
## Summary
- narrow `test_*.py` ignore rule to only affect root scripts
- add `tests/test_api.py` with basic FastAPI health check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410bb9636c8329b6d17c0b8f07489b